### PR TITLE
FEA Introduce `PairwiseDistances`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -95,5 +95,7 @@ sklearn/metrics/_pairwise_distances_reduction/_datasets_pair.pxd
 sklearn/metrics/_pairwise_distances_reduction/_datasets_pair.pyx
 sklearn/metrics/_pairwise_distances_reduction/_middle_term_computer.pxd
 sklearn/metrics/_pairwise_distances_reduction/_middle_term_computer.pyx
+sklearn/metrics/_pairwise_distances_reduction/_pairwise_distances.pxd
+sklearn/metrics/_pairwise_distances_reduction/_pairwise_distances.pyx
 sklearn/metrics/_pairwise_distances_reduction/_radius_neighbors.pxd
 sklearn/metrics/_pairwise_distances_reduction/_radius_neighbors.pyx

--- a/setup.cfg
+++ b/setup.cfg
@@ -96,6 +96,8 @@ ignore =
     sklearn/metrics/_pairwise_distances_reduction/_datasets_pair.pyx
     sklearn/metrics/_pairwise_distances_reduction/_middle_term_computer.pxd
     sklearn/metrics/_pairwise_distances_reduction/_middle_term_computer.pyx
+    sklearn/metrics/_pairwise_distances_reduction/_pairwise_distances.pxd
+    sklearn/metrics/_pairwise_distances_reduction/_pairwise_distances.pyx
     sklearn/metrics/_pairwise_distances_reduction/_radius_neighbors.pxd
     sklearn/metrics/_pairwise_distances_reduction/_radius_neighbors.pyx
 

--- a/setup.py
+++ b/setup.py
@@ -98,6 +98,7 @@ USE_NEWEST_NUMPY_C_API = (
     "sklearn.metrics._pairwise_distances_reduction._datasets_pair",
     "sklearn.metrics._pairwise_distances_reduction._middle_term_computer",
     "sklearn.metrics._pairwise_distances_reduction._base",
+    "sklearn.metrics._pairwise_distances_reduction._pairwise_distances",
     "sklearn.metrics._pairwise_distances_reduction._argkmin",
     "sklearn.metrics._pairwise_distances_reduction._radius_neighbors",
     "sklearn.metrics._pairwise_fast",
@@ -339,6 +340,12 @@ extension_config = {
         },
         {
             "sources": ["_base.pyx.tp", "_base.pxd.tp"],
+            "language": "c++",
+            "include_np": True,
+            "extra_compile_args": ["-std=c++11"],
+        },
+        {
+            "sources": ["_pairwise_distances.pyx.tp", "_pairwise_distances.pxd.tp"],
             "language": "c++",
             "include_np": True,
             "extra_compile_args": ["-std=c++11"],

--- a/sklearn/metrics/_pairwise_distances_reduction/__init__.py
+++ b/sklearn/metrics/_pairwise_distances_reduction/__init__.py
@@ -89,13 +89,18 @@
 from ._dispatcher import (
     BaseDistancesReductionDispatcher,
     ArgKmin,
+    PairwiseDistances,
     RadiusNeighbors,
     sqeuclidean_row_norms,
 )
 
+from ._pairwise_distances import _precompute_metric_params
+
 __all__ = [
     "BaseDistancesReductionDispatcher",
     "ArgKmin",
+    "PairwiseDistances",
     "RadiusNeighbors",
     "sqeuclidean_row_norms",
+    "_precompute_metric_params",
 ]

--- a/sklearn/metrics/_pairwise_distances_reduction/_base.pxd.tp
+++ b/sklearn/metrics/_pairwise_distances_reduction/_base.pxd.tp
@@ -50,6 +50,7 @@ cdef class BaseDistancesReduction{{name_suffix}}:
         ITYPE_t n_samples_X, X_n_samples_chunk, X_n_chunks, X_n_samples_last_chunk
         ITYPE_t n_samples_Y, Y_n_samples_chunk, Y_n_chunks, Y_n_samples_last_chunk
 
+        bint X_is_Y
         bint execute_in_parallel_on_Y
 
     @final

--- a/sklearn/metrics/_pairwise_distances_reduction/_datasets_pair.pxd.tp
+++ b/sklearn/metrics/_pairwise_distances_reduction/_datasets_pair.pxd.tp
@@ -25,6 +25,8 @@ cdef class DatasetsPair{{name_suffix}}:
         {{DistanceMetric}} distance_metric
         ITYPE_t n_features
 
+        readonly bint X_is_Y
+
     cdef ITYPE_t n_samples_X(self) nogil
 
     cdef ITYPE_t n_samples_Y(self) nogil

--- a/sklearn/metrics/_pairwise_distances_reduction/_datasets_pair.pyx.tp
+++ b/sklearn/metrics/_pairwise_distances_reduction/_datasets_pair.pyx.tp
@@ -1,3 +1,5 @@
+import copy
+
 {{py:
 
 implementation_specific_values = [
@@ -91,18 +93,24 @@ cdef class DatasetsPair{{name_suffix}}:
         datasets_pair: DatasetsPair{{name_suffix}}
             The suited DatasetsPair{{name_suffix}} implementation.
         """
-        # Y_norm_squared might be propagated down to DatasetsPairs
-        # via metrics_kwargs when the Euclidean specialisations
-        # can't be used. To prevent Y_norm_squared to be passed
+        # X_norm_squared and Y_norm_squared might be propagated
+        # down to DatasetsPairs via metrics_kwargs when the Euclidean
+        # specialisations can't be used.
+        # To prevent X_norm_squared and Y_norm_squared to be passed
         # down to DistanceMetrics (whose constructors would raise
-        # a RuntimeError), we pop it here.
+        # a RuntimeError), we pop them here.
         if metric_kwargs is not None:
+            # Copying metric_kwargs not to pop "X_norm_squared"
+            # and "Y_norm_squared" where they are used
+            metric_kwargs = copy.copy(metric_kwargs)
+            metric_kwargs.pop("X_norm_squared", None)
             metric_kwargs.pop("Y_norm_squared", None)
         cdef:
             {{DistanceMetric}} distance_metric = {{DistanceMetric}}.get_metric(
                 metric,
                 **(metric_kwargs or {})
             )
+            bint X_is_Y = X is Y
 
         # Metric-specific checks that do not replace nor duplicate `check_array`.
         distance_metric._validate_data(X)
@@ -112,15 +120,15 @@ cdef class DatasetsPair{{name_suffix}}:
         Y_is_sparse = issparse(Y)
 
         if not X_is_sparse and not Y_is_sparse:
-            return DenseDenseDatasetsPair{{name_suffix}}(X, Y, distance_metric)
+            return DenseDenseDatasetsPair{{name_suffix}}(X, Y, distance_metric, X_is_Y)
 
         if X_is_sparse and Y_is_sparse:
-            return SparseSparseDatasetsPair{{name_suffix}}(X, Y, distance_metric)
+            return SparseSparseDatasetsPair{{name_suffix}}(X, Y, distance_metric, X_is_Y)
 
         if X_is_sparse and not Y_is_sparse:
-            return SparseDenseDatasetsPair{{name_suffix}}(X, Y, distance_metric)
+            return SparseDenseDatasetsPair{{name_suffix}}(X, Y, distance_metric, X_is_Y)
 
-        return DenseSparseDatasetsPair{{name_suffix}}(X, Y, distance_metric)
+        return DenseSparseDatasetsPair{{name_suffix}}(X, Y, distance_metric, X_is_Y)
 
     @classmethod
     def unpack_csr_matrix(cls, X: csr_matrix):
@@ -130,8 +138,9 @@ cdef class DatasetsPair{{name_suffix}}:
         X_indptr = np.asarray(X.indptr, dtype=SPARSE_INDEX_TYPE)
         return X_data, X_indices, X_indptr
 
-    def __init__(self, {{DistanceMetric}} distance_metric, ITYPE_t n_features):
+    def __init__(self, {{DistanceMetric}} distance_metric, ITYPE_t n_features, bint X_is_Y):
         self.distance_metric = distance_metric
+        self.X_is_Y = X_is_Y
         self.n_features = n_features
 
     cdef ITYPE_t n_samples_X(self) nogil:
@@ -179,8 +188,9 @@ cdef class DenseDenseDatasetsPair{{name_suffix}}(DatasetsPair{{name_suffix}}):
         const {{INPUT_DTYPE_t}}[:, ::1] X,
         const {{INPUT_DTYPE_t}}[:, ::1] Y,
         {{DistanceMetric}} distance_metric,
+        bint X_is_Y,
     ):
-        super().__init__(distance_metric, n_features=X.shape[1])
+        super().__init__(distance_metric, n_features=X.shape[1], X_is_Y=X_is_Y)
         # Arrays have already been checked
         self.X = X
         self.Y = Y
@@ -219,8 +229,8 @@ cdef class SparseSparseDatasetsPair{{name_suffix}}(DatasetsPair{{name_suffix}}):
         between two vectors of (X, Y).
     """
 
-    def __init__(self, X, Y, {{DistanceMetric}} distance_metric):
-        super().__init__(distance_metric, n_features=X.shape[1])
+    def __init__(self, X, Y, {{DistanceMetric}} distance_metric, bint X_is_Y):
+        super().__init__(distance_metric, n_features=X.shape[1], X_is_Y=X_is_Y)
 
         self.X_data, self.X_indices, self.X_indptr = self.unpack_csr_matrix(X)
         self.Y_data, self.Y_indices, self.Y_indptr = self.unpack_csr_matrix(Y)
@@ -279,8 +289,8 @@ cdef class SparseDenseDatasetsPair{{name_suffix}}(DatasetsPair{{name_suffix}}):
         between two vectors of (X, Y).
     """
 
-    def __init__(self, X, Y, {{DistanceMetric}} distance_metric):
-        super().__init__(distance_metric, n_features=X.shape[1])
+    def __init__(self, X, Y, {{DistanceMetric}} distance_metric, bint X_is_Y):
+        super().__init__(distance_metric, n_features=X.shape[1], X_is_Y=X_is_Y)
 
         self.X_data, self.X_indices, self.X_indptr = self.unpack_csr_matrix(X)
 
@@ -377,10 +387,10 @@ cdef class DenseSparseDatasetsPair{{name_suffix}}(DatasetsPair{{name_suffix}}):
         between two vectors of (X, Y).
     """
 
-    def __init__(self, X, Y, {{DistanceMetric}} distance_metric):
-        super().__init__(distance_metric, n_features=X.shape[1])
+    def __init__(self, X, Y, {{DistanceMetric}} distance_metric, bint X_is_Y):
+        super().__init__(distance_metric, n_features=X.shape[1], X_is_Y=X_is_Y)
         # Swapping arguments on the constructor
-        self.datasets_pair = SparseDenseDatasetsPair{{name_suffix}}(Y, X, distance_metric)
+        self.datasets_pair = SparseDenseDatasetsPair{{name_suffix}}(Y, X, distance_metric, X_is_Y)
 
     @final
     cdef ITYPE_t n_samples_X(self) nogil:

--- a/sklearn/metrics/_pairwise_distances_reduction/_pairwise_distances.pxd.tp
+++ b/sklearn/metrics/_pairwise_distances_reduction/_pairwise_distances.pxd.tp
@@ -1,0 +1,40 @@
+{{py:
+
+implementation_specific_values = [
+    # Values are the following ones:
+    #
+    #       name_suffix, INPUT_DTYPE_t
+    #
+    #
+    ('64', 'cnp.float64_t'),
+    ('32', 'cnp.float32_t')
+]
+
+}}
+cimport numpy as cnp
+
+from ...utils._typedefs cimport DTYPE_t, ITYPE_t
+{{for name_suffix, INPUT_DTYPE_t in implementation_specific_values}}
+
+from ._datasets_pair cimport DatasetsPair{{name_suffix}}
+
+
+cdef class PairwiseDistances{{name_suffix}}:
+    """float{{name_suffix}} implementation of PairwiseDistances."""
+
+    cdef:
+        readonly DatasetsPair{{name_suffix}} datasets_pair
+
+        ITYPE_t n_samples_X, n_samples_Y
+        ITYPE_t effective_n_threads
+        bint X_is_Y
+        bint execute_in_parallel_on_Y
+
+        {{INPUT_DTYPE_t}}[:, ::1] pairwise_distances_matrix
+
+    cdef void _parallel_on_X(self)
+
+    cdef void _parallel_on_Y(self)
+
+
+{{endfor}}

--- a/sklearn/metrics/_pairwise_distances_reduction/_pairwise_distances.pyx.tp
+++ b/sklearn/metrics/_pairwise_distances_reduction/_pairwise_distances.pyx.tp
@@ -1,0 +1,181 @@
+cimport numpy as cnp
+from cython cimport final
+from cython.parallel cimport prange
+from ...utils._typedefs cimport ITYPE_t, DTYPE_t
+
+import numpy as np
+
+from scipy.sparse import issparse
+from sklearn import get_config
+from ...utils import check_array, _in_unstable_openblas_configuration
+from ...utils._openmp_helpers import _openmp_effective_n_threads
+from ...utils.fixes import threadpool_limits, sp_version, parse_version
+from ...utils._typedefs import DTYPE
+
+cnp.import_array()
+
+
+def _precompute_metric_params(X, Y, metric=None, **kwds):
+    """Precompute data-derived metric parameters if not provided."""
+    if metric == "seuclidean" and "V" not in kwds:
+        # There is a bug in scipy < 1.5 that will cause a crash if
+        # X.dtype != np.double (float64). See PR #15730
+        dtype = np.float64 if sp_version < parse_version("1.5") else None
+        if X is Y:
+            V = np.var(X, axis=0, ddof=1, dtype=dtype)
+        else:
+            raise ValueError(
+                "The 'V' parameter is required for the seuclidean metric "
+                "when Y is passed."
+            )
+        return {"V": V}
+    if metric == "mahalanobis" and "VI" not in kwds:
+        if X is Y:
+            VI = np.linalg.inv(np.cov(X.T)).T
+        else:
+            raise ValueError(
+                "The 'VI' parameter is required for the mahalanobis metric "
+                "when Y is passed."
+            )
+        return {"VI": VI}
+    return {}
+
+{{for name_suffix, INPUT_DTYPE in (('64', 'DTYPE'),('32', 'np.float32'))}}
+
+from ._datasets_pair cimport DatasetsPair{{name_suffix}}
+
+
+cdef class PairwiseDistances{{name_suffix}}:
+    """float{{name_suffix}} implementation of PairwiseDistances."""
+
+    @classmethod
+    def compute(
+        cls,
+        X,
+        Y,
+        str metric="euclidean",
+        chunk_size=None,
+        dict metric_kwargs=None,
+        str strategy=None,
+    ):
+        """Compute the pairwise-distances matrix.
+
+        This classmethod is responsible for introspecting the arguments
+        values to dispatch to the most appropriate implementation of
+        :class:`PairwiseDistances{{name_suffix}}`.
+
+        This allows decoupling the API entirely from the implementation details
+        whilst maintaining RAII: all temporarily allocated datastructures necessary
+        for the concrete implementation are therefore freed when this classmethod
+        returns.
+
+        No instance should directly be created outside of this class method.
+        """
+        # Precompute data-derived distance metric parameters
+        metric_kwargs = {} if metric_kwargs is None else metric_kwargs
+
+        params = _precompute_metric_params(
+            X,
+            Y,
+            metric=metric,
+            **metric_kwargs,
+        )
+        metric_kwargs.update(**params)
+
+        # Fall back on a generic implementation that handles most scipy
+        # metrics by computing the distances between 2 vectors at a time.
+        pdr = PairwiseDistances{{name_suffix}}(
+            datasets_pair=DatasetsPair{{name_suffix}}.get_for(X, Y, metric, metric_kwargs),
+            strategy=strategy,
+        )
+
+        # Limit the number of threads in second level of nested parallelism for BLAS
+        # to avoid threads over-subscription (in GEMM for instance).
+        with threadpool_limits(limits=1, user_api="blas"):
+            if pdr.execute_in_parallel_on_Y:
+                pdr._parallel_on_Y()
+            else:
+                pdr._parallel_on_X()
+
+        return pdr._finalize_results()
+
+
+    def __init__(
+        self,
+        DatasetsPair{{name_suffix}} datasets_pair,
+        strategy=None,
+        sort_results=False,
+    ):
+        self.datasets_pair = datasets_pair
+        self.n_samples_X = datasets_pair.n_samples_X()
+        self.n_samples_Y = datasets_pair.n_samples_Y()
+
+        self.effective_n_threads = _openmp_effective_n_threads()
+
+        if strategy is None:
+            strategy = get_config().get("pairwise_dist_parallel_strategy", 'auto')
+
+        if strategy not in ('parallel_on_X', 'parallel_on_Y', 'auto'):
+            raise RuntimeError(f"strategy must be 'parallel_on_X, 'parallel_on_Y', "
+                               f"or 'auto', but currently strategy='{self.strategy}'.")
+
+        if strategy == 'auto':
+            # This is a simple heuristic whose constant for the
+            # comparison has been chosen based on experiments.
+            # parallel_on_X has less synchronization overhead than
+            # parallel_on_Y and should therefore be used whenever
+            # n_samples_X is large enough to not starve any of the
+            # available hardware threads.
+            if self.n_samples_Y < self.n_samples_X:
+                # No point to even consider parallelizing on Y in this case. This
+                # is in particular important to do this on machines with a large
+                # number of hardware threads.
+                strategy = 'parallel_on_X'
+            elif 4 * self.effective_n_threads < self.n_samples_X:
+                # If Y is larger than X, but X is still large enough to allow for
+                # parallelism, we might still want to favor parallelizing on X.
+                strategy = 'parallel_on_X'
+            else:
+                strategy = 'parallel_on_Y'
+
+        self.execute_in_parallel_on_Y = strategy == "parallel_on_Y"
+
+        # Distance matrix which will be complete and returned to the caller.
+        self.pairwise_distances_matrix = np.empty(
+            (self.n_samples_X, self.n_samples_Y), dtype={{INPUT_DTYPE}},
+        )
+
+    cdef void _parallel_on_X(self):
+
+        cdef:
+            ITYPE_t n_X = self.n_samples_X
+            ITYPE_t n_Y = self.n_samples_Y
+            ITYPE_t i, j
+
+        for i in prange(n_X, nogil=True, num_threads=self.effective_n_threads):
+            for j in range(n_Y):
+                self.pairwise_distances_matrix[i, j] = self.datasets_pair.dist(i, j)
+
+    cdef void _parallel_on_Y(self):
+
+        cdef:
+            ITYPE_t n_X = self.n_samples_X
+            ITYPE_t n_Y = self.n_samples_Y
+            ITYPE_t i, j
+
+        for i in range(n_X):
+            for j in prange(n_Y, nogil=True, num_threads=self.effective_n_threads):
+                self.pairwise_distances_matrix[i, j] = self.datasets_pair.dist(i, j)
+
+    def _finalize_results(self):
+        # If X is Y, then catastrophic cancellation might have occurred for
+        # computations of terms on the diagonal which must equal zero.
+        # We enforce it by zeroing the diagonal.
+        distance_matrix = np.asarray(self.pairwise_distances_matrix)
+        if self.datasets_pair.X_is_Y:
+            np.fill_diagonal(distance_matrix, 0.)
+
+        return distance_matrix
+
+
+{{endfor}}

--- a/sklearn/metrics/_pairwise_fast.pyx
+++ b/sklearn/metrics/_pairwise_fast.pyx
@@ -6,10 +6,6 @@
 
 cimport numpy as cnp
 from cython cimport floating
-from cython.parallel cimport prange
-from libc.math cimport fabs
-
-from ..utils._openmp_helpers import _openmp_effective_n_threads
 
 cnp.import_array()
 
@@ -33,79 +29,3 @@ def _chi2_kernel_fast(floating[:, :] X,
                     if nom != 0:
                         res  += denom * denom / nom
                 result[i, j] = -res
-
-
-def _sparse_manhattan(
-    const floating[::1] X_data,
-    const int[:] X_indices,
-    const int[:] X_indptr,
-    const floating[::1] Y_data,
-    const int[:] Y_indices,
-    const int[:] Y_indptr,
-    double[:, ::1] D,
-):
-    """Pairwise L1 distances for CSR matrices.
-
-    Usage:
-    >>> D = np.zeros(X.shape[0], Y.shape[0])
-    >>> _sparse_manhattan(X.data, X.indices, X.indptr,
-    ...                   Y.data, Y.indices, Y.indptr,
-    ...                   D)
-    """
-    cdef cnp.npy_intp px, py, i, j, ix, iy
-    cdef double d = 0.0
-
-    cdef int m = D.shape[0]
-    cdef int n = D.shape[1]
-
-    cdef int X_indptr_end = 0
-    cdef int Y_indptr_end = 0
-
-    cdef int num_threads = _openmp_effective_n_threads()
-
-    # We scan the matrices row by row.
-    # Given row px in X and row py in Y, we find the positions (i and j
-    # respectively), in .indices where the indices for the two rows start.
-    # If the indices (ix and iy) are the same, the corresponding data values
-    # are processed and the cursors i and j are advanced.
-    # If not, the lowest index is considered. Its associated data value is
-    # processed and its cursor is advanced.
-    # We proceed like this until one of the cursors hits the end for its row.
-    # Then we process all remaining data values in the other row.
-
-    # Below the avoidance of inplace operators is intentional.
-    # When prange is used, the inplace operator has a special meaning, i.e. it
-    # signals a "reduction"
-
-    for px in prange(m, nogil=True, num_threads=num_threads):
-        X_indptr_end = X_indptr[px + 1]
-        for py in range(n):
-            Y_indptr_end = Y_indptr[py + 1]
-            i = X_indptr[px]
-            j = Y_indptr[py]
-            d = 0.0
-            while i < X_indptr_end and j < Y_indptr_end:
-                ix = X_indices[i]
-                iy = Y_indices[j]
-
-                if ix == iy:
-                    d = d + fabs(X_data[i] - Y_data[j])
-                    i = i + 1
-                    j = j + 1
-                elif ix < iy:
-                    d = d + fabs(X_data[i])
-                    i = i + 1
-                else:
-                    d = d + fabs(Y_data[j])
-                    j = j + 1
-
-            if i == X_indptr_end:
-                while j < Y_indptr_end:
-                    d = d + fabs(Y_data[j])
-                    j = j + 1
-            else:
-                while i < X_indptr_end:
-                    d = d + fabs(X_data[i])
-                    i = i + 1
-
-            D[px, py] = d

--- a/sklearn/metrics/tests/test_pairwise_distances_reduction.py
+++ b/sklearn/metrics/tests/test_pairwise_distances_reduction.py
@@ -14,6 +14,7 @@ from sklearn.metrics._pairwise_distances_reduction import (
     BaseDistancesReductionDispatcher,
     ArgKmin,
     RadiusNeighbors,
+    PairwiseDistances,
     sqeuclidean_row_norms,
 )
 
@@ -750,6 +751,44 @@ def test_radius_neighbors_factory_method_wrong_usages():
         RadiusNeighbors.compute(
             X=X, Y=Y, radius=radius, metric=metric, metric_kwargs=metric_kwargs
         )
+
+
+def test_pairwise_distances_factory_method_wrong_usages():
+    rng = np.random.RandomState(1)
+    X = rng.rand(100, 10)
+    Y = rng.rand(100, 10)
+    metric = "euclidean"
+
+    msg = (
+        "Only float64 or float32 datasets pairs are supported, but "
+        "got: X.dtype=float32 and Y.dtype=float64"
+    )
+    with pytest.raises(
+        ValueError,
+        match=msg,
+    ):
+        PairwiseDistances.compute(X=X.astype(np.float32), Y=Y, metric=metric)
+
+    msg = (
+        "Only float64 or float32 datasets pairs are supported, but "
+        "got: X.dtype=float64 and Y.dtype=int32"
+    )
+    with pytest.raises(
+        ValueError,
+        match=msg,
+    ):
+        PairwiseDistances.compute(X=X, Y=Y.astype(np.int32), metric=metric)
+
+    with pytest.raises(ValueError, match="Unrecognized metric"):
+        PairwiseDistances.compute(X=X, Y=Y, metric="wrong metric")
+
+    with pytest.raises(
+        ValueError, match=r"Buffer has wrong number of dimensions \(expected 2, got 1\)"
+    ):
+        PairwiseDistances.compute(X=np.array([1.0, 2.0]), Y=Y, metric=metric)
+
+    with pytest.raises(ValueError, match="ndarray is not C-contiguous"):
+        PairwiseDistances.compute(X=np.asfortranarray(X), Y=Y, metric=metric)
 
 
 @pytest.mark.parametrize(

--- a/sklearn/neighbors/_nca.py
+++ b/sklearn/neighbors/_nca.py
@@ -486,7 +486,7 @@ class NeighborhoodComponentsAnalysis(
         X_embedded = np.dot(X, transformation.T)  # (n_samples, n_components)
 
         # Compute softmax distances
-        p_ij = pairwise_distances(X_embedded, squared=True)
+        p_ij = pairwise_distances(X_embedded, metric="sqeuclidean")
         np.fill_diagonal(p_ij, np.inf)
         p_ij = softmax(-p_ij)  # (n_samples, n_samples)
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Towards https://github.com/scikit-learn/scikit-learn/pull/23958

#### What does this implement/fix? Explain your changes.
This simplifies the original implementation of `PairwiseDistance` by @jjerphan, with the following differences:
- `PairwiseDistance{32,64}` doesn't subclass `BaseBaseDistancesReduction{32,64}` anymore.
- This allows to add `_parallel_on_{X,Y}` methods to `PairwiseDistance{32,64}`, since these methods are decorated with `@final` in `BaseBaseDistancesReduction{32,64}` and thus can't be overwritten.
- This also remove the chunk computing mechanism, by considering only the case `chunk_size = 1`, as proposed by @ogrisel in [this comment](https://github.com/scikit-learn/scikit-learn/pull/23958#issuecomment-1280517094).
- This doesn't implement the Euclidean specialization yet to make benchmarks simpler.

Following [this benchmark](https://gist.github.com/Vincent-Maladiere/67e9efa5fc02cbe48e052b97372115af), we found that this PR yields a significant performance regression when `n_jobs = 1` and an improvement when `n_jobs > 1`, for both euclidean and manhattan distances:

![euclidean](https://user-images.githubusercontent.com/18560386/216777160-a48b1578-d890-464a-8a92-ffe0ca707134.png)

![manhattan](https://user-images.githubusercontent.com/18560386/216777169-b6686780-ae12-4da7-be50-b5965c5bd7aa.png)

#### Any other comments?

As suggested by @jjerphan, decorating `DistanceMetric` subclasses with `@final` could alleviate some of the overhead and make this implementation competitive with `main` when `n_jobs=1`.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
